### PR TITLE
Validation for missing input

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -24,72 +24,21 @@ onstart:
 rule all:
     input:
         expand(f"{cfg.data_root}/{{tissue}}/{{tissue}}_config.yaml", tissue=set(data.tissues)),
-        f"{cfg.genome.species_dir}/{cfg.species_name}_{cfg.genome.ensembl_release}_{cfg.genome.type}.fa",
-        f"{cfg.genome.contaminants_dir}/.download_complete",
-        f"{cfg.genome.species_dir}/star/Log.out",
-        f"{cfg.genome.species_dir}/transcriptome.fa",
-
-        expand(f"{cfg.data_root}/{{tissue}}/layouts/{{tissue}}_{{tag}}_layout.txt", zip, tissue=data.tissues, tag=data.tags),
-        expand(f"{cfg.data_root}/{{tissue}}/prepMethods/{{tissue}}_{{tag}}_prep_method.txt",zip,tissue=data.tissues,tag=data.tags),
-        expand(f"{cfg.data_root}/{{tissue}}/align/{{tag}}/{{tissue}}_{{tag}}.bam",zip,tissue=data.tissues,tag=data.tags),
-        expand(f"{cfg.como_root}/{{tissue}}/geneCounts/{{study}}/{{tissue}}_{{tag}}.tab",zip,tissue=data.tissues,study=data.studies,tag=data.tags),
         expand(f"{cfg.data_root}/{{tissue}}/multiqc/{cfg.sample_filepath.stem}/{cfg.sample_filepath.stem}_multiqc_report.html",tissue=set(data.tissues)),
-        branch(
-            cfg.perform.dump_fastq,
-            then=[
-                expand(f"{cfg.data_root}/{{tissue}}/raw/{{tissue}}_{{tag}}_{{end}}.fastq.gz",zip,tissue=data.tissues_paired,tag=data.tags_paired,end=data.ends_paired),
-                expand(
-                    f"{cfg.data_root}/{{tissue}}/fastqc/raw/raw_{{tissue}}_{{tag}}_{{end}}_fastqc.zip",
-                    zip,
-                    tissue=data.tissues_paired,
-                    tag=data.tags_paired,
-                    end=data.ends_paired
-                ),
-            ],
-            otherwise=[],
-        ),
-        branch(
-            cfg.perform.trim,
-            then=[
-                expand(f"{cfg.data_root}/{{tissue}}/trim/{{tissue}}_{{tag}}_{{end}}.fastq.gz",zip,tissue=data.tissues_paired,tag=data.tags_paired,end=data.ends_paired),
-                expand(
-                    f"{cfg.data_root}/{{tissue}}/fastqc/trimmed/trimmed_{{tissue}}_{{tag}}_{{end}}_fastqc.zip",
-                    zip,
-                    tissue=data.tissues_paired,
-                    tag=data.tags_paired,
-                    end=data.ends_paired
-                ),
-            ],
-            otherwise=[],
-        ),
-        branch(
-            cfg.perform.contaminant_screen,
-            then=f"{cfg.genome.contaminants_dir}/fastq_screen.conf",
-            otherwise=[],
-        ),
+        expand(f"{cfg.como_root}/{{tissue}}/geneCounts/{{study}}/{{tissue}}_{{tag}}.tab",zip,tissue=data.tissues,study=data.studies,tag=data.tags),
         branch(
             cfg.perform.fragment_size,
-            then=[
-                expand(f"{cfg.data_root}/{{tissue}}/fragmentSizes/{{tissue}}_{{tag}}_fragment_size.txt", zip, tissue=data.tissues, tag=data.tags),
-                expand(f"{cfg.como_root}/{{tissue}}/fragmentSizes/{{study}}/{{tissue}}_{{tag}}_fragment_size.txt",zip,tissue=data.tissues,study=data.studies,tag=data.tags)
-            ],
+            then=[expand(f"{cfg.como_root}/{{tissue}}/fragmentSizes/{{study}}/{{tissue}}_{{tag}}_fragment_size.txt",zip,tissue=data.tissues,study=data.studies,tag=data.tags)],
             otherwise=[]
         ),
         branch(
             cfg.perform.rnaseq_metrics,
-            then=[
-                expand(f"{cfg.data_root}/{{tissue}}/picard/rnaseq/{{tissue}}_{{tag}}_rnaseq.txt", zip, tissue=data.tissues, tag=data.tags),
-                expand(f"{cfg.como_root}/{{tissue}}/strandedness/{{study}}/{{tissue}}_{{tag}}_strandedness.txt",zip,tissue=data.tissues,tag=data.tags,study=data.studies),
-            ],
+            then=[expand(f"{cfg.como_root}/{{tissue}}/strandedness/{{study}}/{{tissue}}_{{tag}}_strandedness.txt",zip,tissue=data.tissues,tag=data.tags,study=data.studies)],
             otherwise=[],
         ),
         branch(
             cfg.perform.insert_size,
-            then=[
-                expand(f"{cfg.data_root}/{{tissue}}/picard/insert/{{tissue}}_{{tag}}_insert_size.txt",zip,tissue=data.tissues,tag=data.tags),
-                expand(f"{cfg.data_root}/{{tissue}}/picard/hist/{{tissue}}_{{tag}}_insert_size_histo.pdf",zip,tissue=data.tissues,tag=data.tags),
-                expand(f"{cfg.como_root}/{{tissue}}/insertSizeMetrics/{{study}}/{{tissue}}_{{tag}}_insert_size.txt",zip,tissue=data.tissues,tag=data.tags,study=data.studies),
-            ],
+            then=[expand(f"{cfg.como_root}/{{tissue}}/insertSizeMetrics/{{study}}/{{tissue}}_{{tag}}_insert_size.txt",zip,tissue=data.tissues,tag=data.tags,study=data.studies)],
             otherwise=[]
         )
 
@@ -324,7 +273,7 @@ rule fastq_dump_paired:
         sra_cache="$tmpdir/sra_cache"
         fastq_cache="$tmpdir/fastq_cache"
         mkdir -p "$sra_cache" "$fastq_cache"
-        
+
         prefetch --max-size u --progress --log-level info --force ALL --output-directory "$sra_cache" {params.srr} 1>{log} 2>&1
 
         sra_temp="$sra_cache/{params.srr}.sra"
@@ -366,7 +315,7 @@ rule fastq_dump_single:
         mkdir -p "$sra_cache" "$fastq_cache"
 
         prefetch --max-size u --progress --log-level info --force ALL --output-directory "$sra_cache" {params.srr} 1>>{log} 2>&1
-        
+
         sra_file="$sra_cache/{params.srr}/{params.srr}.sra"
         fastq_file="$fastq_cache/{params.srr}.fastq"
         fasterq-dump --force --concatenate-reads --progress --threads {threads} --temp "$fastq_cache" --outdir "$fastq_cache" "$sra_file" 1>>{log} 2>&1
@@ -450,6 +399,8 @@ rule qc_raw_fastq_single:
         mv --verbose "$tmpdir/{wildcards.tissue}_{wildcards.tag}_S_fastqc.zip" "{output.s_zip}" 1>>{log} 2>&1
         mv --verbose "$tmpdir/{wildcards.tissue}_{wildcards.tag}_S_fastqc.html" "{output.s_html}" 1>>{log} 2>&1
         """
+
+
 def trim_paired_input(wildcards) -> dict[Literal["r1"] | Literal["r2"], str | list[str]]:
     if cfg.perform.dump_fastq:
         return {"r1": rules.fastq_dump_paired.output.r1, "r2": rules.fastq_dump_paired.output.r2}
@@ -981,7 +932,6 @@ def multiqc_contamination_input(wildcards) -> list[str]:
         tissues, tags = se_samples["sample"].str.split(n=1, pat="_", expand=True).T.values
         files += expand(rules.contaminant_screen_single.output.S, zip, tissue=tissues, tag=tags)
     return files
-
 
 rule multiqc:
     input:

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -119,9 +119,11 @@ class Config:
     def _validate_config(config: dict[str, Any]):  # noqa: C901
         if config["MASTER_CONTROL"] == "":
             raise ValueError("MASTER_CONTROL cannot be an empty string.")
+        if config["MASTER_CONTROL"] == config["LOCAL_FASTQ_FILES"] == "":
+            raise ValueError("Either MASTER_CONTROL or LOCAL_FASTQ_FILES must be provided.")
         if not Path(config["MASTER_CONTROL"]).exists():
             raise FileNotFoundError(f"MASTER_CONTROL path does not exist: {config['MASTER_CONTROL']}")
-        
+
         if not str(config["BENCHMARK_TIMES"]).isdigit() or int(config["BENCHMARK_TIMES"]) < 0:
             raise ValueError("BENCHMARK_TIMES must be a non-negative integer.")
 
@@ -161,7 +163,6 @@ class Config:
         fastq_files = config["LOCAL_FASTQ_FILES"]
         taxon_id: int = int(config["GENOME"]["TAXONOMY_ID"])
         species_name: str = species_from_taxon(taxon_id=taxon_id)
-
 
         return cls(
             sample_filepath=Path(config["MASTER_CONTROL"]),


### PR DESCRIPTION
# Features
1) Simplify rule `all` inputs, reducing the number of arrows in the generated rulegraph
2) Simplify rule `multiqc` inputs by removing `lambda wildcards:` in all places not necessary
3) Improve configuration validation by requiring at least the sample filepath OR a local directory of FastQ files